### PR TITLE
Search Results Customizations

### DIFF
--- a/app/assets/stylesheets/modules/search_form.scss
+++ b/app/assets/stylesheets/modules/search_form.scss
@@ -7,3 +7,22 @@ button#search {
   border-top-right-radius: 0.25rem;
   border-bottom-right-radius: 0.25rem;
 }
+
+@include media-breakpoint-down(sm) {
+  form.search-query-form {
+    span.input-group-append {
+      width:100%;
+      padding-top:0.25rem;
+
+      button.search-btn {
+        width:50%;
+        border-top-left-radius: 0.25rem;
+        border-bottom-left-radius: 0.25rem;
+      }
+
+      a.advanced_search {
+        width:50%;
+      }
+    }
+  }
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -100,7 +100,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'dct_spatial_sm', :label => 'Place', :limit => 8, collapse: false
     config.add_facet_field 'b1g_genre_sm', :label => 'Genre', :limit => 8, collapse: false
     config.add_facet_field 'solr_year_i', label: 'Year', limit: 10, collapse: false, all: 'Any year', range: {
-      assumed_boundaries: [1100, 2018]
+      assumed_boundaries: [1100, Time.now.year]
       # :num_segments => 6,
       # :segments => true
     }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -245,10 +245,11 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, dc_title_sort asc', :label => 'relevance'
-    config.add_sort_field "#{Settings.FIELDS.YEAR} desc, dc_title_sort asc", :label => 'year'
-    config.add_sort_field "#{Settings.FIELDS.PUBLISHER} asc, dc_title_sort asc", :label => 'publisher'
-    config.add_sort_field 'dc_title_sort asc', :label => 'title'
+    config.add_sort_field 'score desc, dc_title_sort asc', :label => 'Relevance'
+    config.add_sort_field "#{Settings.FIELDS.YEAR} desc, dc_title_sort asc", :label => 'Year (Newest first)'
+    config.add_sort_field "#{Settings.FIELDS.YEAR} asc, dc_title_sort asc", :label => 'Year (Oldest first)'
+    config.add_sort_field 'dc_title_sort asc', :label => 'Title (A-Z)'
+    config.add_sort_field 'dc_title_sort desc', :label => 'Title (Z-A)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -97,20 +97,35 @@ class CatalogController < ApplicationController
     #    :years_25 => { :label => 'within 25 Years', :fq => "pub_date:[#{Time.now.year - 25 } TO *]" }
     # }
 
-    config.add_facet_field Settings.FIELDS.PROVENANCE, label: 'Institution', limit: 8, partial: "icon_facet"
-    config.add_facet_field Settings.FIELDS.CREATOR, :label => 'Author', :limit => 8
-    config.add_facet_field Settings.FIELDS.PUBLISHER, :label => 'Publisher', :limit => 8
-    config.add_facet_field Settings.FIELDS.SUBJECT, :label => 'Subject', :limit => 8
-    config.add_facet_field Settings.FIELDS.SPATIAL_COVERAGE, :label => 'Place', :limit => 8
-    config.add_facet_field Settings.FIELDS.PART_OF, :label => 'Collection', :limit => 8
-
-    config.add_facet_field Settings.FIELDS.YEAR, label: 'Year', limit: 10, collapse: false, all: 'Any year', range: {
-      assumed_boundaries: [1100, 2020]
+    config.add_facet_field 'dct_spatial_sm', :label => 'Place', :limit => 8, collapse: false
+    config.add_facet_field 'b1g_genre_sm', :label => 'Genre', :limit => 8, collapse: false
+    config.add_facet_field 'solr_year_i', label: 'Year', limit: 10, collapse: false, all: 'Any year', range: {
+      assumed_boundaries: [1100, 2018]
+      # :num_segments => 6,
+      # :segments => true
     }
+    config.add_facet_field 'dc_subject_sm', :label => 'Subject', :limit => 8, collapse: false
 
-    config.add_facet_field Settings.FIELDS.RIGHTS, label: 'Access', limit: 8, partial: "icon_facet"
-    config.add_facet_field Settings.FIELDS.GEOM_TYPE, label: 'Data type', limit: 8, partial: "icon_facet"
-    config.add_facet_field Settings.FIELDS.FILE_FORMAT, :label => 'Format', :limit => 8
+    config.add_facet_field 'time_period', :label => 'Time Period', :query => {
+      '1500s' => { :label => '1500s', :fq => "solr_year_i:[1500 TO 1599]" },
+      '1600s' => { :label => '1600s', :fq => "solr_year_i:[1600 TO 1699]" },
+      '1700s' => { :label => '1700s', :fq => "solr_year_i:[1700 TO 1799]" },
+      '1800-1849' => { :label => '1800-1849', :fq => "solr_year_i:[1800 TO 1849]" },
+      '1850-1899' => { :label => '1850-1899', :fq => "solr_year_i:[1850 TO 1899]" },
+      '1900-1949' => { :label => '1900-1949', :fq => "solr_year_i:[1900 TO 1949]" },
+      '1950-1999' => { :label => '1950-1999', :fq => "solr_year_i:[1950 TO 1999]" },
+      '2000-2004' => { :label => '2000-2004', :fq => "solr_year_i:[2000 TO 2004]" },
+      '2005-2009' => { :label => '2005-2009', :fq => "solr_year_i:[2005 TO 2009]" },
+      '2010-2014' => { :label => '2010-2014', :fq => "solr_year_i:[2010 TO 2014]" },
+      '2015-present' => { :label => '2015-present', :fq => "solr_year_i:[2015 TO #{Time.now.year}]"}
+    }, collapse: false
+
+    config.add_facet_field 'dc_publisher_sm', :label => 'Publisher', :limit => 8
+    config.add_facet_field 'dc_creator_sm', :label => 'Creator', :limit => 8
+
+    config.add_facet_field Settings.FIELDS.PROVENANCE, label: 'Institution', limit: 8, partial: "icon_facet"
+
+    config.add_facet_field 'dc_type_sm', label: 'Type', limit: 8
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,0 +1,9 @@
+<% if query_has_constraints? %>
+<div id="appliedParams" class="clearfix constraints-container">
+  <div class="pull-right">
+    <%=link_to t('blacklight.search.start_over'), root_path({:utf8 => '✓', :q => '', :search_field => 'all_fields'}), :class => "catalog_startOverLink btn btn-primary", :id=>"startOverLink" %>
+  </div>
+  <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
+  <%= render_constraints(params) %>
+</div>
+<% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,7 @@
 en:
   blacklight:
     application_name: 'JHU GeoPortal'
+    range_limit:
+      submit_limit: 'Limit'
+    search:
+      start_over: 'Clear search'

--- a/test/system/advanced_search_test.rb
+++ b/test/system/advanced_search_test.rb
@@ -10,7 +10,7 @@ class AdvancedSearchPageTest < ApplicationSystemTestCase
     assert page.has_content?("Limit Results By")
     within("div.limit-criteria") do
       assert page.has_content?("Institution")
-      assert page.has_content?("Author")
+      assert page.has_content?("Creator")
       assert page.has_content?("Year")
     end
 

--- a/test/system/search_results_test.rb
+++ b/test/system/search_results_test.rb
@@ -1,0 +1,72 @@
+require "application_system_test_case"
+
+class SearchResultsPageTest < ApplicationSystemTestCase
+  def setup
+  end
+
+  def test_basic_dom
+    visit '/?q=water'
+    assert page.has_selector?("header#topnav")          # JHU Branding
+    assert page.has_selector?("nav#header-navbar")      # Static Pages
+    assert page.has_selector?("nav#search-navbar")      # Search Form
+    assert page.has_selector?("div#main-container")     # Main
+    within("div#main-container") do
+      assert page.has_selector?("div#appliedParams")    # Constraints
+      assert page.has_selector?("section#content")      # Results
+      assert page.has_selector?("div.page-links")       # Pagination
+      assert page.has_selector?("div.search-widgets")   # Result Options
+      assert page.has_selector?("div#sort-dropdown")    # Sorting
+      assert page.has_selector?("div#per_page-dropdown")# Per Page
+      assert page.has_selector?("section#sidebar")      # Facets
+    end
+
+    assert page.has_selector?("footer")                 # Footer
+  end
+
+  def test_search
+    visit '/?q=water'
+    assert page.has_content?("Search Results")
+    assert page.has_content?("You searched for")
+    assert page.has_link?("Clear search")
+  end
+
+  def test_map_clustering
+    skip("MarkerCluster not yet implemented")
+    # Map centered on USA. Records have cluster centroid values.
+    visit '/?utf8=✓&view=mapview&q=&search_field=all_fields&bbox=-177.129822%20-36.81918%20-28.067322%2074.70319'
+    assert page.has_selector?("div.marker-cluster")
+  end
+
+  def test_empty_search
+    visit '/?utf8=✓&q=&search_field=all_fields'
+    assert page.assert_selector('article.document', :count => 10)
+  end
+
+  def test_facets
+    visit '/?utf8=✓&q=&search_field=all_fields'
+    assert page.has_selector?("#facets")
+    within("#facets") do
+      assert page.has_content?("Place")
+      assert page.has_content?("Genre")
+      assert page.has_content?("Year")
+      assert page.has_content?("Subject")
+      assert page.has_content?("Time Period")
+      assert page.has_content?("Publisher")
+      assert page.has_content?("Creator")
+      assert page.has_content?("Institution")
+      assert page.has_content?("Type")
+    end
+  end
+
+  def test_sort_options
+    visit '/?q=water'
+    click_button("Sort by Relevance")
+    within("#sort-dropdown") do
+      assert page.has_content?("Relevance")
+      assert page.has_content?("Year (Newest first)")
+      assert page.has_content?("Year (Oldest first)")
+      assert page.has_content?("Title (A-Z)")
+      assert page.has_content?("Title (Z-A)")
+    end
+  end
+end


### PR DESCRIPTION
Adds customized JHU facet order, facet labels, and search constraint views (a la B1G). Includes Rails system tests for search result DOM, copy, and features.

Addresses #25 
![JHU GeoPortal Search Results](https://user-images.githubusercontent.com/69827/74554565-785a8480-4f1f-11ea-85ce-c6053fc07cd6.png)

