### PR TITLE
Show Page Customizations

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -163,8 +163,11 @@ class CatalogController < ApplicationController
     # link_to_search: [Boolean] that can be passed to link to a facet search
     # helper_method: [Symbol] method that can be used to render the value
     config.add_show_field Settings.FIELDS.CREATOR, label: 'Author(s)', itemprop: 'author'
-    config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
     config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
+    config.add_show_field Settings.FIELDS.RIGHTS, label: 'Access'
+
+    config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
+
     config.add_show_field Settings.FIELDS.PART_OF, label: 'Collection', itemprop: 'isPartOf'
     config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial', link_to_facet: true
     config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject(s)', itemprop: 'keywords', link_to_facet: true
@@ -271,6 +274,9 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && (Settings.METADATA_SHOWN & options[:document].references.refs.map(&:type).map(&:to_s)).any? }
     config.add_show_tools_partial :exports, partial: 'exports', if: proc { |_context, _config, options| options[:document] }
     config.add_show_tools_partial :data_dictionary, partial: 'data_dictionary', if: proc { |_context, _config, options| options[:document] }
+
+    # JHU Customizations
+    config.show.document_actions.delete(:bookmark)
 
     # Configure basemap provider for GeoBlacklight maps (uses https only basemap
     # providers with open licenses)

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,7 +1,7 @@
 <% if query_has_constraints? %>
 <div id="appliedParams" class="clearfix constraints-container">
   <div class="pull-right">
-    <%=link_to t('blacklight.search.start_over'), root_path({:utf8 => '✓', :q => '', :search_field => 'all_fields'}), :class => "catalog_startOverLink btn btn-primary", :id=>"startOverLink" %>
+    <%=link_to t('blacklight.search.start_over').html_safe, root_path({:utf8 => '✓', :q => '', :search_field => 'all_fields'}), :class => "catalog_startOverLink btn btn-primary", :id=>"startOverLink" %>
   </div>
   <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
   <%= render_constraints(params) %>

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,0 +1,17 @@
+<% #Using the Bootstrap Pagination class  -%>
+<div class='pagination-search-widgets'>
+  <%=link_to t('blacklight.search.start_over').html_safe, start_over_path(current_search_session.try(:query_params) || {}), id: 'startOverLink', class: 'btn btn-primary button--start-over' %>
+  <% if current_search_session %>
+    <%= link_back_to_catalog class: 'btn btn-outline-primary button--back-to-search', label:  t('blacklight.back_to_search').html_safe %>
+  <% end %>
+
+  <% if @search_context && (@search_context[:prev] || @search_context[:next]) %>
+    <div class="page-links">
+      <%= link_to_previous_document @search_context[:prev] %> |
+
+      <%= item_page_entry_info %> |
+
+      <%= link_to_next_document @search_context[:next] %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,0 +1,5 @@
+<%= render_document_main_content_partial %>
+
+<% content_for(:sidebar) do %>
+  <%= render_document_sidebar_partial @document %>
+<% end %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -12,7 +12,7 @@
   </div>
 </nav>
 
-<% if controller_name == 'catalog' && has_search_parameters? %>
+<% if controller_name == 'catalog' && (has_search_parameters? || params[:action] == 'show') %>
   <nav id="search-navbar" class="navbar navbar-expand-md navbar-light bg-jhu-gray" role="navigation">
     <div class="container">
       <div class='col-lg-8 my-3 col-xs-12'>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,7 +1,9 @@
 en:
   blacklight:
     application_name: 'JHU GeoPortal'
+    back_to_search: 'Back to search'
     range_limit:
       submit_limit: 'Limit'
     search:
-      start_over: 'Clear search'
+      start_over: 'Start over'
+      clear_search: 'Clear search'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,9 +1,15 @@
 en:
   blacklight:
     application_name: 'JHU GeoPortal'
-    back_to_search: 'Back to search'
+    back_to_search: '<span class="icon-moveback"><svg class="bi bi-arrow-left" width="1em" height="1em" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" d="M7.854 6.646a.5.5 0 010 .708L5.207 10l2.647 2.646a.5.5 0 01-.708.708l-3-3a.5.5 0 010-.708l3-3a.5.5 0 01.708 0z" clip-rule="evenodd"></path>
+  <path fill-rule="evenodd" d="M4.5 10a.5.5 0 01.5-.5h10.5a.5.5 0 010 1H5a.5.5 0 01-.5-.5z" clip-rule="evenodd"></path>
+</svg></span> <span class="d-none d-md-inline-block">Back to search</span>'
     range_limit:
       submit_limit: 'Limit'
     search:
-      start_over: 'Start over'
+      start_over: '<span class="icon-refresh align-middle"><svg class="bi bi-arrow-counterclockwise" width="1em" height="1em" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" d="M10 4.5A5.5 5.5 0 114.5 10a.5.5 0 00-1 0 6.5 6.5 0 103.25-5.63l.5.865A5.472 5.472 0 0110 4.5z" clip-rule="evenodd"></path>
+  <path fill-rule="evenodd" d="M9.354 1.646a.5.5 0 00-.708 0l-2.5 2.5a.5.5 0 000 .708l2.5 2.5a.5.5 0 10.708-.708L7.207 4.5l2.147-2.146a.5.5 0 000-.708z" clip-rule="evenodd"></path>
+</svg></span> <span class="align-middle">Start over</span>'
       clear_search: 'Clear search'

--- a/test/system/homepage_test.rb
+++ b/test/system/homepage_test.rb
@@ -11,7 +11,7 @@ class HomepageTest < ApplicationSystemTestCase
     assert page.has_selector?("div#main-container")     # Main
     assert page.has_selector?("form.search-query-form") # Search Form
     assert page.has_selector?("div#map")                # Map
-    assert page.has_selector?("div.leaflet-pane")        # Leaflet
+    assert page.has_selector?("div.leaflet-pane")       # Leaflet
     assert page.has_selector?("footer")                 # Footer
   end
 

--- a/test/system/search_results_test.rb
+++ b/test/system/search_results_test.rb
@@ -27,7 +27,7 @@ class SearchResultsPageTest < ApplicationSystemTestCase
     visit '/?q=water'
     assert page.has_content?("Search Results")
     assert page.has_content?("You searched for")
-    assert page.has_link?("Clear search")
+    assert page.has_link?("Start over")
   end
 
   def test_map_clustering

--- a/test/system/show_page_test.rb
+++ b/test/system/show_page_test.rb
@@ -9,6 +9,7 @@ class ShowPageTest < ApplicationSystemTestCase
 
     assert page.has_selector?("header#topnav")              # JHU Branding
     assert page.has_selector?("nav#header-navbar")          # Static Pages
+    assert page.has_selector?("nav#search-navbar")          # Search Form
     assert page.has_selector?("div#main-container")         # Main
     within("div#main-container") do
       assert page.has_selector?("section.show-document")    # Document

--- a/test/system/show_page_test.rb
+++ b/test/system/show_page_test.rb
@@ -33,4 +33,18 @@ class ShowPageTest < ApplicationSystemTestCase
     end
     assert page.has_selector?("footer")                     # Footer
   end
+
+  def test_show_page_search_nav
+    visit '/?utf8=✓&q=&search_field=all_fields'
+    within("div#documents") do
+      find("a", match: :first).click
+    end
+
+    assert page.has_selector?('div.pagination-search-widgets')
+    within("div.pagination-search-widgets") do
+      assert page.has_link?("Start over")                    # Start over
+      assert page.has_link?("Back to search")                # Back to search
+      assert page.has_selector?("div.page-links")            # Pagination
+    end
+  end
 end

--- a/test/system/show_page_test.rb
+++ b/test/system/show_page_test.rb
@@ -1,0 +1,36 @@
+require "application_system_test_case"
+
+class ShowPageTest < ApplicationSystemTestCase
+  def setup
+  end
+
+  def test_basic_dom
+    visit "/catalog/stanford-cz128vq0535"
+
+    assert page.has_selector?("header#topnav")              # JHU Branding
+    assert page.has_selector?("nav#header-navbar")          # Static Pages
+    assert page.has_selector?("div#main-container")         # Main
+    within("div#main-container") do
+      assert page.has_selector?("section.show-document")    # Document
+    end
+    within("section.show-document") do
+      assert page.has_selector?("div#document")
+    end
+    within("section.show-document") do
+      assert page.has_selector?("h2")                       # Title
+      assert page.has_selector?("dl.document-metadata")     # Metadata
+      assert page.has_selector?("div#viewer-container")     # Viewer
+    end
+    within("div#viewer-container") do
+      assert page.has_selector?("h3.help-text")             # Help Text
+      assert page.has_selector?("div#map")                  # Map
+    end
+    assert page.has_selector?("section.page-sidebar")       # Sidebar
+    within("section.page-sidebar") do
+      assert page.has_selector?("div.show-tools")           # Tools
+      assert page.has_selector?("div.downloads")            # Downloads
+      assert page.has_selector?("div.exports")              # Exports
+    end
+    assert page.has_selector?("footer")                     # Footer
+  end
+end


### PR DESCRIPTION
Adds customized JHU show page: facet order, prev/next buttons, button icons, persistent search bar. Includes Rails system tests for show page DOM and features.

Addresses #34 

![2016 NYC Geodatabase  ArcGIS Version  jan2016  - JHU GeoPortal (1)](https://user-images.githubusercontent.com/69827/74881619-425c3c80-5333-11ea-802a-53a1916665ed.png)


